### PR TITLE
200% publish rate and PID vals for gripper fingers

### DIFF
--- a/robots/LoCoBot/locobot_gazebo/config/control.yaml
+++ b/robots/LoCoBot/locobot_gazebo/config/control.yaml
@@ -1,7 +1,7 @@
 # Publish all joint states -----------------------------------
 joint_state_controller:
   type: joint_state_controller/JointStateController
-  publish_rate: 100
+  publish_rate: 200
 
 # Position Controllers ---------------------------------------
 joint_1_cntrl:
@@ -56,3 +56,9 @@ tilt:
 #     joint_3: {p: 300.0, i: 1.0, d: 0.1}
 #     joint_4: {p: 300.0, i: 1.0, d: 0.1}
 #     joint_5: {p: 30.0, i: 10.0, d: 0.1}
+
+gains:
+     joint_6: {p: 30.0, i: 10.0, d: 0.1}
+     joint_7: {p: 30.0, i: 10.0, d: 0.1}
+
+


### PR DESCRIPTION
These changes were made while trying to improve LoCoBot's gripper friction (in order to help it pick up a cube object). It isn't clear if these changes (increased publish rate and added PID values) are having an effect on solving the gripper friction issue but everything is known to be working as required with these parameters in place.